### PR TITLE
fix: Fix optional imports and hash map field case

### DIFF
--- a/protoc-gen-polyglot-rs/internal/version/version.go
+++ b/protoc-gen-polyglot-rs/internal/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 const (
-	Version = "v0.5.0"
+	Version = "v0.5.1"
 )

--- a/protoc-gen-polyglot-rs/pkg/generator/generator.go
+++ b/protoc-gen-polyglot-rs/pkg/generator/generator.go
@@ -120,6 +120,8 @@ func (g *Generator) ExecuteTemplate(
 	header bool,
 ) error {
 	var buf bytes.Buffer
+	deps := DependencyAnalysis(protoFile)
+
 	err := g.templ.ExecuteTemplate(&buf, "base.templ", map[string]interface{}{
 		"pluginVersion":   version.Version,
 		"sourcePath":      protoFile.Desc.Path(),
@@ -128,6 +130,7 @@ func (g *Generator) ExecuteTemplate(
 		"enums":           protoFile.Desc.Enums(),
 		"messages":        protoFile.Desc.Messages(),
 		"header":          header,
+		"dependencies":    deps,
 	})
 	if err != nil {
 		return err

--- a/protoc-gen-polyglot-rs/templates/decodeMap.templ
+++ b/protoc-gen-polyglot-rs/templates/decodeMap.templ
@@ -1,7 +1,7 @@
 {{define "decodeMap"}}
 {{ $mapKeyValue := FindValue .MapKey }}
 {{ $mapValueValue := FindValue .MapValue }}
-fn {{ .Name }}_decode(b: &mut Cursor<&mut Vec<u8>>) -> Result<Option<HashMap<{{ $mapKeyValue }}, {{ $mapValueValue }}>>, DecodingError> {
+fn {{ SnakeCaseName .Name }}_decode(b: &mut Cursor<&mut Vec<u8>>) -> Result<Option<HashMap<{{ $mapKeyValue }}, {{ $mapValueValue }}>>, DecodingError> {
     if b.decode_none() {
         return Ok(None);
     }

--- a/protoc-gen-polyglot-rs/templates/encode.templ
+++ b/protoc-gen-polyglot-rs/templates/encode.templ
@@ -44,8 +44,8 @@ impl Encode for {{ CamelCase .FullName }} {
         {{ if $field.IsMap -}}
             {{ $keyKind := GetKind $field.MapKey.Kind -}}
             {{ $valKind := GetKind $field.MapValue.Kind -}}
-            b.encode_map(self.{{ $field.Name }}.len(), {{ $keyKind }}, {{ $valKind }})?;
-            for (k, v) in self.{{ $field.Name }} {
+            b.encode_map(self.{{ SnakeCaseName $field.Name }}.len(), {{ $keyKind }}, {{ $valKind }})?;
+            for (k, v) in self.{{ SnakeCaseName $field.Name }} {
             {{ $keyEncoder := GetLUTEncoder $field.MapKey.Kind -}}
             {{ if and (eq $keyEncoder "") (eq $field.MapKey.Kind 11) -}} {{/* protoreflect.MessageKind */ -}}
             k.encode(b)?;

--- a/protoc-gen-polyglot-rs/templates/imports.templ
+++ b/protoc-gen-polyglot-rs/templates/imports.templ
@@ -1,8 +1,12 @@
 {{define "imports"}}
 use std::io::Cursor;
 use polyglot::{DecodingError, Encoder, Decoder, Kind};
+{{ if .dependencies.Enums -}}
 use num_enum::TryFromPrimitive;
 use std::convert::TryFrom;
+{{ end -}}
+{{ if .dependencies.Maps -}}
 use std::collections::HashMap;
+{{ end -}}
 use std::io;
 {{end}}


### PR DESCRIPTION
## Description
Fixes an issue where imports for hash maps and enums were included even if those types were not actually used in the proto file
Fixes an issue where hash map field names inside encoders and decoders would not be corrected to follow rust style guidelines, resulting in a reference error. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']

## Testing

## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `cargo fmt --all -- --check` has been run
- [x] `clip` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
