### PR TITLE
Prevent snakecase converter from adding underscores inside acronyms

### DIFF
--- a/protoc-gen-polyglot-rs/pkg/utils/utils.go
+++ b/protoc-gen-polyglot-rs/pkg/utils/utils.go
@@ -74,14 +74,17 @@ func CamelCase(s string) string {
 
 func SnakeCase(s string) string {
 	var b bytes.Buffer
+	var consc bool
 	for _, c := range s {
 		if 'A' <= c && c <= 'Z' {
-			if b.Len() > 0 {
+			if b.Len() > 0 && !consc {
 				b.WriteRune('_')
 			}
 			b.WriteRune(c - 'A' + 'a')
+			consc = true
 		} else {
 			b.WriteRune(c)
+			consc = false
 		}
 	}
 	return b.String()


### PR DESCRIPTION
## Description
Fixes an issue where the naming converter would add underscores between the letters of acronyms, e.g field IP would be converted to i_p

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [x] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']


## Linting

Please make sure you've run the following and fixed any issues that arise:

- [x] `cargo fmt --all -- --check` has been run
- [x] `clip` has been run

## Final Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
